### PR TITLE
Add message & severity as labels to output

### DIFF
--- a/sensu_exporter.go
+++ b/sensu_exporter.go
@@ -62,11 +62,21 @@ func (c *SensuCollector) Collect(ch chan<- prometheus.Metric) {
 		log.Debugln("...", fmt.Sprintf("%d, %v, %v", i, result.Check.Name, result.Check.Status))
 		// in Sensu, 0 means OK
 		// in Prometheus, 1 means OK
+		// More here: https://docs.sensu.io/sensu-core/1.9/reference/checks/#sensu-check-specification
 		status := 0.0
+		severity := "warning"
 		if result.Check.Status == 0 {
 			status = 1.0
-		} else {
-			status = 0.0
+			severity = "ok"
+		}
+		if result.Check.Status == 1 {
+			severity = "warning"
+		}
+		if result.Check.Status == 2 {
+			severity = "critical"
+		}
+		if result.Check.Status > 2 {
+			severity = "unknown"
 		}
 		ch <- prometheus.MustNewConstMetric(
 			c.CheckStatus,
@@ -75,6 +85,7 @@ func (c *SensuCollector) Collect(ch chan<- prometheus.Metric) {
 			result.Client,
 			result.Check.Name,
 			result.Check.Output,
+			severity,
 		)
 	}
 }
@@ -107,7 +118,7 @@ func NewSensuCollector(url string, cli *http.Client) *SensuCollector {
 		CheckStatus: prometheus.NewDesc(
 			"sensu_check_status",
 			"Sensu Check Status(1:Up, 0:Down)",
-			[]string{"client", "check_name", "check_message"},
+			[]string{"client", "check_name", "check_message", "check_severity"},
 			nil,
 		),
 	}

--- a/sensu_exporter.go
+++ b/sensu_exporter.go
@@ -74,6 +74,7 @@ func (c *SensuCollector) Collect(ch chan<- prometheus.Metric) {
 			status,
 			result.Client,
 			result.Check.Name,
+			result.Check.Output,
 		)
 	}
 }
@@ -106,7 +107,7 @@ func NewSensuCollector(url string, cli *http.Client) *SensuCollector {
 		CheckStatus: prometheus.NewDesc(
 			"sensu_check_status",
 			"Sensu Check Status(1:Up, 0:Down)",
-			[]string{"client", "check_name"},
+			[]string{"client", "check_name", "check_message"},
 			nil,
 		),
 	}


### PR DESCRIPTION
* Retrieves the message from the `/results` endpoint and adds it as a label to the output (`check_message`)
* Uses the `status` field and adds a `check_severity` label based on the value. [Spec here](https://docs.sensu.io/sensu-core/1.9/reference/checks/#sensu-check-specification)