### PR TITLE
Fix the timeout default (was 20ns, is now 20s)

### DIFF
--- a/sensu_exporter.go
+++ b/sensu_exporter.go
@@ -6,13 +6,14 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 )
 
 var (
-	timeout       = flag.Duration("timeout", 20, "Timeout in seconds for the API request")
+	timeout       = flag.Duration("timeout", time.Second * 20, "Timeout for the API request")
 	listenAddress = flag.String(
 		// exporter port list:
 		// https://github.com/prometheus/prometheus/wiki/Default-port-allocations


### PR DESCRIPTION
The current default is easily verifiable via `--help`:
```
Usage of /bin/sensu_exporter:
  -api string
    	Address to Sensu API. (default "http://localhost:4567")
  -listen string
    	Address to listen on for serving Prometheus Metrics. (default ":9251")
  -timeout duration
    	Timeout in seconds for the API request (default 20ns)
```

This PR multiplies the `20` default with `time.Seconds`, that's it.

EDIT: And the helptext said "in seconds". Since we are using `time.Duration` now this is not true. It would actually be nanoseconds. So I just removed that part, the default should be an OK hint that you need to use a unit suffix.