### PR TITLE
Add caching feature for large sensu results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ _testmain.go
 *.exe
 *.test
 *.prof
+
+sensu_exporter
+

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ make
 $ ./sensu_exporter --help
 Usage of ./sensu_exporter:
   -api string
-    Address to Sensu API. (default "http://localhost:4567")
+      Address to Sensu API. (default "http://localhost:4567")
   -listen string
-    Address to listen on for serving Prometheus Metrics. (default ":9251")
+      Address to listen on for serving Prometheus Metrics. (default ":9251")
   -timeout duration
-    Timeout in seconds for the API request (default 20ns)
+      Timeout in seconds for the API request (default 20ns)
   -cache
-    Enable caching of results.  Reduces scrape time for large results datasets by pulling data between prometheus scrapes instead of blocking.
+      Enable caching of results.  Reduces scrape time for large results datasets by pulling data between prometheus scrapes instead of blocking.
 ```
 
 ## Exported Metrics

--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ make
 $ ./sensu_exporter --help
 Usage of ./sensu_exporter:
   -api string
-      Address to Sensu API. (default "http://localhost:4567")
+    Address to Sensu API. (default "http://localhost:4567")
   -listen string
-      Address to listen on for serving Prometheus Metrics. (default ":9251")
+    Address to listen on for serving Prometheus Metrics. (default ":9251")
+  -timeout duration
+    Timeout in seconds for the API request (default 20ns)
+  -cache
+    Enable caching of results.  Reduces scrape time for large results datasets by pulling data between prometheus scrapes instead of blocking.
 ```
 
 ## Exported Metrics

--- a/go.mod
+++ b/go.mod
@@ -4,3 +4,5 @@ require (
 	github.com/prometheus/client_golang v0.9.2
 	github.com/prometheus/common v0.2.0
 )
+
+go 1.13


### PR DESCRIPTION
For extremely large Sensu result sets, the query time can be 10s of seconds.  This PR adds a caching feature that allows the exporter to pull the results sets between scrapes to improve scrape time.